### PR TITLE
marked.jsを移用した変換処理への変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,10 +18,19 @@
 
 		gtag('config', 'G-1N62PKEYVX');
 	</script>
+	<script src="path/to/marked.min.js"></script>
 	<script>
 		const SITE_TITLE = "ひらめきのきらめき"
-		var fileReferences;
-		var fileReferencedBy;
+		var fileData;
+
+		var renderer = new marked.Renderer();
+		renderer.link = function (href, title, text) {
+			if (href.startsWith('?')) {
+				return `<a href="${href}" onclick="a(${href}); retufn false;">${text}</a>`;
+			} else {
+				return `<a href="${href} target="_blank">${text}</a>`;
+			}
+		};
 
 		function convertMarkdownToHtml(markdown, indent = 0) {
 			// 改行コードを LF に統一する
@@ -78,19 +87,14 @@
 			window.scrollTo(0, 0);
 		}
 
-		// fileAndLinkという変数が未定義の場合、"file_references.json"をfetchしてデータを取得し、変数に格納する
+		// fileAndLinkという変数が未定義の場合、"file_data.json"をfetchしてデータを取得し、変数に格納する
 		// ファイル名が指定されていない場合は、デフォルトのファイル名を設定する
 		async function showData() {
 			console.log("showData");
 
-			if (!fileReferences) {
-				const response = await fetch('ref/file_references.json');
-				fileReferences = await response.json();
-			}
-
-			if (!fileReferencedBy) {
-				const response = await fetch('ref/file_referenced_by.json');
-				fileReferencedBy = await response.json();
+			if (!fileData) {
+				const response = await fetch('ref/file_data.json');
+				fileData = await response.json();
 			}
 
 			fileName = decodeURI(location.search.substring(1));
@@ -119,7 +123,7 @@
 			element.classList.remove("hidden");
 			element.classList.add("visible");
 
-			fileReferences[fileName].forEach(f => {
+			fileData[fileName]["references"].forEach(f => {
 				appendContent(f);
 			});
 
@@ -137,20 +141,22 @@
 					// マークダウン記法による文字列操作
 					let data = `#${fileName}\r\n${text}`;
 
-					// 参照されているファイルのリストを追加
-					if (fileReferencedBy[fileName]) {
-						data += "\r\n\r\n##関連のありそうなページ\r\n";
-						fileReferencedBy[fileName].forEach(referencedBy => {
-							data += `- ${referencedBy}\r\n`;
-						});
-					}
-
 					// リンクの変換を実施する
-					if (fileReferences[fileName].length > 0) {
-						let regex = new RegExp(`(${fileReferences[fileName].join('|')})`, 'g');
-						data = data.replace(regex, "[$1]qj(?$1)");
+					if (fileData[fileName].length > 0) {
+						let regex = new RegExp(`(${fileData[fileName].join('|')})`, 'g');
+						data = data.replace(regex, "[$1](?$1)");
 					}
 					data = convertMarkdownToHtml(data);
+
+					// 参照されているファイルのリストを追加
+					if (fileData[fileName]["referenced_by"]) {
+						data += "<h2>関連のありそうなページ</h2>";
+						var list = "";
+						fileData[fileName]["referenced_by"].forEach(referencedBy => {
+							list += `<li>${referencedBy}</li>`;
+						});
+						data += `<ul>${list}</ul>`;
+					}
 
 					// 要素を作成し、データを追加する
 					const container = document.createElement("section");

--- a/spa_generate_link.py
+++ b/spa_generate_link.py
@@ -13,31 +13,23 @@ def extract_filename(file_path):
 filenames = [extract_filename(f) for f in os.listdir(folder_path) if os.path.isfile(
     os.path.join(folder_path, f)) and f.endswith('.md')]
 
-references = {filename: [] for filename in filenames}
-referenced_by = {filename: [] for filename in filenames}
+file_data = {filename: {"referenced_by": [], "references": []} for filename in filenames}
 
 for filename in filenames:
     file_path = os.path.join(folder_path, f"_{filename}.md")
     with open(file_path, 'r', encoding='utf-8') as f:
         content = f.read()
-        for ref_filename in referenced_by.keys():
+        for ref_filename in file_data.keys():
             if filename != ref_filename and ref_filename in content:
-                references[filename].append(ref_filename)
-                referenced_by[ref_filename].append(filename)
+                file_data[filename]["references"].append(ref_filename)
+                file_data[ref_filename]["referenced_by"].append(filename)
 
-for filename, refs in referenced_by.items():
-    references[filename].extend(refs)
-    references[filename] = list(set(references[filename]))  # 重複を削除
-    references[filename].sort(key=len, reverse=True)  # 文字列が長い順に並び替え
+for filename, data in file_data.items():
+    data["references"].sort(key=len, reverse=True)  # 文字列が長い順に並び替え
 
-output_file_path = os.path.join(output_path, 'file_references.json')
+output_file_path = os.path.join(output_path, 'file_data.json')
 with open(output_file_path, 'w', encoding='utf-8') as f:
-    json.dump(references, f, ensure_ascii=False, indent=4)
-
-# Save referenced_by as a separate JSON file
-referenced_output_file_path = os.path.join(output_path, 'file_referenced_by.json')
-with open(referenced_output_file_path, 'w', encoding='utf-8') as f:
-    json.dump(referenced_by, f, ensure_ascii=False, indent=4)
+    json.dump(file_data, f, ensure_ascii=False, indent=4)
 
 # Create sitemap.xml using ElementTree
 urlset = ET.Element('urlset', {'xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9'})


### PR DESCRIPTION
自作のマークダウン変換はメンテナンス性に難があり、かつ世間一般への共通認識が弱いため、一般的に使用されているmarked.jsに変更する。 内部リンクはパラメータによって制御されているため、?から始まるリンクの場合は内部リンク、それ以外は外部リンクと判定し、リンクの変換方法を分岐する。